### PR TITLE
Adicionar outputs

### DIFF
--- a/how-to-use-this-module/outputs.tf
+++ b/how-to-use-this-module/outputs.tf
@@ -1,1 +1,3 @@
-
+output "compute_cluster_gcp_how_to_use" {
+  value = module.iac-modulo-compute-cluster-gcp[*].compute_cluster_gcp[*]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,1 +1,7 @@
-
+output "compute_cluster_gcp" {
+  value       = {
+    client-node = module.compute_gcp[*].client-node
+    server-node = module.compute_gcp[*].server-node
+  }
+  description = "The Public and Private IPs of client and server nodes"
+}


### PR DESCRIPTION
# Adicionar outputs dos IPs


- [x] Garanta que seu topic/feature/bugfix branch tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue
#5 

## Objetivo
Esse PR tem como objetivo adicionar outputs referentes aos IPs públicos e privados das instancias da GCP

## Referências

- https://www.terraform.io/docs/language/values/outputs.html

## Como testar
 
```bash
cd how-to-use-this-module
make plan
```

No plan (ou no apply), devem aparecer os outputs dos módulos.
Caso ja tenham sido aplicados, pode-se fazer:
```bash
terraform refresh -lock=false
terraform output
```

## Caveats

1. Como o module `compute_gcp` utiliza outro modulo, o `github.com/mentoriaiac/iac-modulo-compute-gcp.git`, os outputs do modulo do `compute_gcp` são dependentes dos outputs do módulo pai. Sendo assim, não há como mudar que informações aparecem no output, a não ser alterando o módulo pai, porém, tem como apresenta-los de uma forma melhor e mais legível
2. Atualmente, eu estou "restringindo" o output aos node lists `client-node` e `server-node`, que são os que são usados no `how-to-use-this-module`. Nao sei se esses nomes vão mudar, se mudarem, vai quebrar o output. Posso fazer mais genérico, se assim for o caso.